### PR TITLE
First attempt at Ohio transformer file

### DIFF
--- a/src/main/python/.gitignore
+++ b/src/main/python/.gitignore
@@ -1,3 +1,3 @@
 nohup.out
 __pycache__
-
+*.pyc

--- a/src/main/python/transformers/oh_transformer.py
+++ b/src/main/python/transformers/oh_transformer.py
@@ -1,0 +1,347 @@
+from base_transformer import BaseTransformer
+import usaddress
+
+class OHTransformer(BaseTransformer):
+
+    """
+    A few required columns in the BaseTransformer did not have values in the
+    Ohio data. Not sure what the best way of updating those on a case by case
+    basis is, but given how irregular some files are it might just be worth
+    allowing None for all columns
+    """
+    col_type_dict = BaseTransformer.col_type_dict.copy()
+    col_type_dict['TITLE'] = set([str, type(None)])
+    col_type_dict['GENDER'] = set([str, type(None)])
+    col_type_dict['COUNTYCODE'] = set([str, type(None)])
+    col_type_dict['ABSENTEE_TYPE'] = set([str, type(None)])
+    col_type_dict['PRECINCT_SPLIT'] = set([str, type(None)])
+
+    #### Contact methods #######################################################
+
+    def extract_name(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'TITLE'
+                'FIRST_NAME'
+                'MIDDLE_NAME'
+                'LAST_NAME'
+                'NAME_SUFFIX'
+        """
+        output_dict = {
+            'TITLE': None,
+            'FIRST_NAME': input_dict['FIRST_NAME'],
+            'MIDDLE_NAME': input_dict['MIDDLE_NAME'],
+            'LAST_NAME': input_dict['LAST_NAME'],
+            'NAME_SUFFIX': input_dict['SUFFIX'],
+        }
+        return output_dict
+
+    def extract_email(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'EMAIL'
+        """
+        return {'EMAIL': None}
+
+    def extract_phone_number(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'PHONE'
+        """
+        return {'PHONE': None}
+
+    def extract_do_not_call_status(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'DO_NOT_CALL_STATUS'
+        """
+        return {'DO_NOT_CALL_STATUS': None}
+
+    #### Demographics methods ##################################################
+
+    def extract_gender(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'GENDER'
+        """
+        return {'GENDER': None}
+
+    def extract_birthdate(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'BIRTHDATE'
+        """
+        return {'BIRTHDATE': self.convert_date(input_dict['DATE_OF_BIRTH'])}
+
+    def extract_language_choice(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'LANGUAGE_CHOICE'
+        """
+        return {'LANGUAGE_CHOICE': None}
+
+    #### Address methods #######################################################
+
+    def extract_registration_address(self, input_dict):
+        """
+        Relies on the usaddress package.
+
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'ADDRESS_NUMBER'
+                'ADDRESS_NUMBER_PREFIX'
+                'ADDRESS_NUMBER_SUFFIX'
+                'BUILDING_NAME'
+                'CORNER_OF'
+                'INTERSECTION_SEPARATOR'
+                'LANDMARK_NAME'
+                'NOT_ADDRESS'
+                'OCCUPANCY_TYPE'
+                'OCCUPANCY_IDENTIFIER'
+                'PLACE_NAME'
+                'STATE_NAME'
+                'STREET_NAME'
+                'STREET_NAME_PRE_DIRECTIONAL'
+                'STREET_NAME_PRE_MODIFIER'
+                'STREET_NAME_PRE_TYPE'
+                'STREET_NAME_POST_DIRECTIONAL'
+                'STREET_NAME_POST_MODIFIER'
+                'STREET_NAME_POST_TYPE'
+                'SUBADDRESS_IDENTIFIER'
+                'SUBADDRESS_TYPE'
+                'USPS_BOX_GROUP_ID'
+                'USPS_BOX_GROUP_TYPE'
+                'USPS_BOX_ID'
+                'USPS_BOX_TYPE'
+                'ZIP_CODE'
+        """
+        address_components = [
+            'RESIDENTIAL_ADDRESS1',
+            'RESIDENTIAL_SECONDARY_ADDR',
+            'RESIDENTIAL_CITY',
+            'RESIDENTIAL_STATE',
+            'RESIDENTIAL_ZIP'
+        ]
+        address_str = ' '.join([
+            input_dict[x] for x in address_components if input_dict[x] is not None
+        ])
+        usaddress_dict, usaddress_type = self.usaddress_tag(address_str)
+        return self.convert_usaddress_dict(usaddress_dict)
+
+    def extract_county_code(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'COUNTYCODE'
+        """
+        return {'COUNTYCODE': None}
+
+    def extract_mailing_address(self, input_dict):
+        """
+        Relies on the usaddress package.
+
+        We provide template code.
+
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'MAIL_ADDRESS_LINE1'
+                'MAIL_ADDRESS_LINE2'
+                'MAIL_CITY'
+                'MAIL_STATE'
+                'MAIL_ZIP_CODE'
+                'MAIL_COUNTRY'
+        """
+        mail_str = ' '.join([
+            x for x in [
+                input_dict['MAILING_ADDRESS1'],
+                input_dict['MAILING_SECONDARY_ADDRESS'],
+                input_dict['MAILING_CITY'],
+                input_dict['MAILING_STATE'],
+                input_dict['MAILING_ZIP'],
+                input_dict['MAILING_COUNTRY'],
+            ] if x is not None
+        ])
+        # TODO: default to residential address?
+        usaddress_dict, usaddress_type = self.usaddress_tag(mail_str)
+        return {
+            'MAIL_ADDRESS_LINE1': self.construct_mail_address_1(
+                usaddress_dict,
+                usaddress_type,
+            ),
+            'MAIL_ADDRESS_LINE2': self.construct_mail_address_2(usaddress_dict),
+            'MAIL_CITY': input_dict['MAILING_CITY'],
+            'MAIL_ZIP_CODE': input_dict['MAILING_ZIP'],
+            'MAIL_STATE': input_dict['MAILING_STATE'],
+            'MAIL_COUNTRY': input_dict['MAILING_COUNTRY'],
+        }
+
+    #### Political methods #####################################################
+
+    def extract_state_voter_ref(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'STATE_VOTER_REF'
+        """
+        return {'STATE_VOTER_REF': input_dict['SOS_VOTERID']}
+
+    def extract_county_voter_ref(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'COUNTY_VOTER_REF'
+        """
+        return {'COUNTY_VOTER_REF': input_dict['COUNTY_ID']}
+
+    def extract_registration_date(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'REGISTRATION_DATE'
+        """
+        date = self.convert_date(input_dict['REGISTRATION_DATE'])
+        return {'REGISTRATION_DATE': date}
+
+    def extract_registration_status(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'REGISTRATION_STATUS'
+        """
+        return {'REGISTRATION_STATUS': input_dict['VOTER_STATUS']}
+
+    def extract_absentee_type(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'ABSTENTEE_TYPE'
+        """
+        return {'ABSENTEE_TYPE': None}
+
+    def extract_party(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'PARTY'
+        """
+        party = input_dict['PARTY_AFFILIATION']
+        if party == 'R':
+            party = 'REP'
+        elif party == 'D':
+            party = 'DEM'
+        else:
+            party = None
+
+        return {'PARTY': party}
+
+    def extract_congressional_dist(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'CONGRESSIONAL_DIST'
+        """
+        return {'CONGRESSIONAL_DIST': input_dict['CONGRESSIONAL_DISTRICT']}
+
+    def extract_upper_house_dist(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'UPPER_HOUSE_DIST'
+        """
+        return {'UPPER_HOUSE_DIST': input_dict['STATE_SENATE_DISTRICT']}
+
+    def extract_lower_house_dist(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'LOWER_HOUSE_DIST'
+        """
+        return {'LOWER_HOUSE_DIST': input_dict['STATE_REPRESENTATIVE_DISTRICT']}
+
+    def extract_precinct(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'PRECINCT'
+        """
+        return {'PRECINCT': input_dict['PRECINCT_CODE']}
+
+    def extract_county_board_dist(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'COUNTY_BOARD_DIST'
+        """
+        # Not sure if mapping exists, verify
+        return {'COUNTY_BOARD_DIST': None}
+
+    def extract_school_board_dist(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'SCHOOL_BOARD_DIST'
+        """
+        # Not sure if mapping exists, verify
+        return {'SCHOOL_BOARD_DIST': None}
+
+    def extract_precinct_split(self, input_dict):
+        """
+        Inputs:
+            input_dict: dictionary of form {colname: value} from raw data
+        Outputs:
+            Dictionary with following keys
+                'PRECINCT_SPLIT'
+        """
+        # Not sure if mapping exists, verify
+        return {'PRECINCT_SPLIT': None}

--- a/src/main/python/transformers/oh_transformer.py
+++ b/src/main/python/transformers/oh_transformer.py
@@ -188,18 +188,43 @@ class OHTransformer(BaseTransformer):
                 input_dict['MAILING_COUNTRY'],
             ] if x is not None
         ])
-        # TODO: default to residential address?
-        usaddress_dict, usaddress_type = self.usaddress_tag(mail_str)
+
+        # If mailing address provided, parse, otherwise default to residential
+        # strip() required because input_dict vals are spaces
+        # May want to make this default behavior
+        if len(mail_str.strip()) > 0:
+            usaddress_dict, usaddress_type = self.usaddress_tag(mail_str)
+            mail_city = input_dict['MAILING_CITY']
+            mail_zip = input_dict['MAILING_ZIP']
+            mail_state = input_dict['MAILING_STATE']
+            mail_country = input_dict['MAILING_COUNTRY']
+        else:
+            address_components = [
+                'RESIDENTIAL_ADDRESS1',
+                'RESIDENTIAL_SECONDARY_ADDR',
+                'RESIDENTIAL_CITY',
+                'RESIDENTIAL_STATE',
+                'RESIDENTIAL_ZIP'
+            ]
+            address_str = ' '.join([
+                input_dict[x] for x in address_components if input_dict[x] is not None
+            ])
+            usaddress_dict, usaddress_type = self.usaddress_tag(address_str)
+            mail_city = input_dict['RESIDENTIAL_CITY']
+            mail_zip = input_dict['RESIDENTIAL_ZIP']
+            mail_state = input_dict['RESIDENTIAL_STATE']
+            mail_country = 'USA'
+
         return {
             'MAIL_ADDRESS_LINE1': self.construct_mail_address_1(
                 usaddress_dict,
                 usaddress_type,
             ),
             'MAIL_ADDRESS_LINE2': self.construct_mail_address_2(usaddress_dict),
-            'MAIL_CITY': input_dict['MAILING_CITY'],
-            'MAIL_ZIP_CODE': input_dict['MAILING_ZIP'],
-            'MAIL_STATE': input_dict['MAILING_STATE'],
-            'MAIL_COUNTRY': input_dict['MAILING_COUNTRY'],
+            'MAIL_CITY': mail_city,
+            'MAIL_ZIP_CODE': mail_zip,
+            'MAIL_STATE': mail_state,
+            'MAIL_COUNTRY': mail_country,
         }
 
     #### Political methods #####################################################

--- a/src/main/python/transformers/ohio_prepare.py
+++ b/src/main/python/transformers/ohio_prepare.py
@@ -1,0 +1,9 @@
+from oh_transformer import OHTransformer
+
+if __name__ == '__main__':
+    oh_transformer = OHTransformer(date_format="%Y-%m-%d", sep=',')
+    # Used Sandusky County data from https://www6.sos.state.oh.us/ords/f?p=111:1
+    oh_transformer(
+        # '../../../../../SANDUSKY.TXT',
+        # '../../../../../sandusky_test_out.csv',
+    )


### PR DESCRIPTION
Taking a first stab a #71 with the Ohio voter file and tried it out on Sandusky County. 

Not sure about the best way of updating the type restrictions from `BaseTransformer`, but there were a few required items not included so I just made a copy and overwrote those columns. It might be worth considering making all columns allow `None`. 

Also, the original `OhioPrepare.py` file defaults mailing address information to the residential address information if none is provided, do we want to do that here as well?